### PR TITLE
Include path in child filters field names

### DIFF
--- a/Nested2Find.Tests/Nested2Find.Tests.csproj
+++ b/Nested2Find.Tests/Nested2Find.Tests.csproj
@@ -43,10 +43,13 @@
       <HintPath>..\packages\FluentAssertions.2.0.0.1\lib\net40\FluentAssertions.dll</HintPath>
     </Reference>
     <Reference Include="Machine.Specifications">
-      <HintPath>..\packages\Machine.Specifications.0.5.9\lib\net40\Machine.Specifications.dll</HintPath>
+      <HintPath>..\packages\Machine.Specifications.0.8.3\lib\net45\Machine.Specifications.dll</HintPath>
     </Reference>
     <Reference Include="Machine.Specifications.Clr4">
-      <HintPath>..\packages\Machine.Specifications.0.5.9\lib\net40\Machine.Specifications.Clr4.dll</HintPath>
+      <HintPath>..\packages\Machine.Specifications.0.8.3\lib\net45\Machine.Specifications.Clr4.dll</HintPath>
+    </Reference>
+    <Reference Include="Machine.Specifications.Should">
+      <HintPath>..\packages\Machine.Specifications.Should.0.7.2\lib\net45\Machine.Specifications.Should.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Nested2Find.Tests/Stories/Nested.cs
+++ b/Nested2Find.Tests/Stories/Nested.cs
@@ -312,6 +312,118 @@ namespace Nested2Find.Stories
         }
     }
 
+    public class Nested4 : IDisposable
+    {
+        [Fact]
+        public void FilterByMultipleValuesForANestedListOfComplexObjectsWithDupplicatePropertyNamesUsingFilterDelegateBuilder()
+        {
+            new Story("Filter by matching a specific item in a list")
+                .InOrderTo("be able to filter by several values on objects in lists of complex objects having similar property names")
+                .AsA("developer")
+                .IWant("to be able to map list of complex objects as nested and filter by multiple values in a unique object in the list")
+                .WithScenario("mapping list of complex objects as nested")
+                .Given(IHaveAClient)
+                    .And(IHaveMappedIEnumerablePropertiesAsNested)
+                    .And(IHaveTwoCompanyObjects)
+                    .And(IHaveTwoDepartmentObjects)
+                    .And(TheFirstDepartmentHasAnEmployeeNamedCristianoRonaldo)
+                    .And(TheSecondDepartmentHasAnEmployeeNamedCristianoDoe)
+                    .And(TheSecondDepartmentHasAnEmployeeNamedJohnRonaldo)
+                    .And(TheFirstDepartmentBelongsToTheFirstCompany)
+                    .And(TheSecondDepartmentBelongsToTheSecondCompany)
+                    .And(IHaveIndexedTheCompanyObjects)
+                    .And(IHaveWaitedForASecond)
+                .When(ISearchForCompanyWithDepartmentWithAnEmployeeWithNameCristianoAndLastNameRonaldo)
+                .Then(IShouldGetASingleHit)
+                .And(ItShouldBeForTheFirstDepartment)
+                .Execute();
+        }
+
+        protected IClient client;
+        void IHaveAClient()
+        {
+            client = Client.CreateFromConfig();
+        }
+
+        void IHaveMappedIEnumerablePropertiesAsNested()
+        {
+            client.Conventions.AddNestedConventions();
+        }
+
+        private Company company1, company2;
+        void IHaveTwoCompanyObjects()
+        {
+            company1 = new Company("Company 1");
+            company2 = new Company("Company 2");
+        }
+
+        private Department department1, department2;
+        void IHaveTwoDepartmentObjects()
+        {
+            department1 = new Department("Department 1");
+            department2 = new Department("Department 2");
+        }
+
+        void TheFirstDepartmentHasAnEmployeeNamedCristianoRonaldo()
+        {
+            department1.Employees.Add(new Employee { Name = "Cristiano", LastName = "Ronaldo" });
+        }
+
+        void TheSecondDepartmentHasAnEmployeeNamedCristianoDoe()
+        {
+            department2.Employees.Add(new Employee { Name = "Cristiano", LastName = "Doe" });
+        }
+
+        void TheSecondDepartmentHasAnEmployeeNamedJohnRonaldo()
+        {
+            department2.Employees.Add(new Employee { Name = "John", LastName = "Ronaldo" });
+        }
+
+        void TheFirstDepartmentBelongsToTheFirstCompany()
+        {
+            company1.Departments.Add(department1);
+        }
+
+        void TheSecondDepartmentBelongsToTheSecondCompany()
+        {
+            company2.Departments.Add(department2);
+        }
+
+        void IHaveIndexedTheCompanyObjects()
+        {
+            client.Index(company1, company2);
+        }
+
+        void IHaveWaitedForASecond()
+        {
+            Thread.Sleep(1000);
+        }
+
+        SearchResults<Company> result;
+        void ISearchForCompanyWithDepartmentWithAnEmployeeWithNameCristianoAndLastNameRonaldo()
+        {
+            result = client.Search<Company>()
+                        .Filter(x => x.Departments.MatchItem(t => t.Employees.MatchItem(p => p.Name.Match("Cristiano") & p.LastName.Match("Ronaldo"))))
+                        .GetResult();
+        }
+
+        void IShouldGetASingleHit()
+        {
+            result.TotalMatching.Should().Be(1);
+        }
+
+        void ItShouldBeForTheFirstDepartment()
+        {
+            result.Single().Name.Should().Be(company1.Name);
+        }
+
+        public void Dispose()
+        {
+            client.Delete<Company>(x => x.Name.Match(company1.Name));
+            client.Delete<Company>(x => x.Name.Match(company2.Name));
+        }
+    }
+
     public class League
     {
         public League(string name)
@@ -338,5 +450,36 @@ namespace Nested2Find.Stories
     {
         public string FirstName { get; set; }
         public string LastName { get; set; }
+    }
+
+    public class Company
+    {
+        public Company(string name)
+        {
+            Name = name;
+            Departments = new NestedList<Department>();
+        }
+
+        public string Name { get; set; }
+        public NestedList<Department> Departments { get; set; } 
+    }
+
+    public class Department
+    {
+        public Department(string name)
+        {
+            Name = name;
+            Employees = new NestedList<Employee>();
+        }
+
+        public string Name { get; set; }
+        public NestedList<Employee> Employees { get; set; }
+    }
+
+    public class Employee
+    {
+        public string Name { get; set; }
+        public string LastName { get; set; }
+
     }
 }

--- a/Nested2Find.Tests/Stories/Nested.cs
+++ b/Nested2Find.Tests/Stories/Nested.cs
@@ -4,8 +4,10 @@ using System.Linq;
 using System.Linq.Expressions;
 using EPiServer.Find;
 using EPiServer.Find.Api.Querying.Filters;
-using EPiServer.Find.ClientConventions;
-using FluentAssertions;
+﻿using EPiServer.Find.Api.Querying.Queries;
+﻿using EPiServer.Find.ClientConventions;
+﻿using EPiServer.Find.Helpers.Text;
+﻿using FluentAssertions;
 using StoryQ;
 using Xunit;
 using System.Threading;
@@ -13,7 +15,7 @@ using Nested2Find.ClientConventions;
 
 namespace Nested2Find.Stories
 {
-    public class Nested
+    public class Nested : IDisposable
     {
         [Fact]
         public void FilterByMultipleValuesForAComplexObjectInAListUsingFilter()
@@ -97,9 +99,16 @@ namespace Nested2Find.Stories
         {
             result.Single().TeamName.Should().Be(team1.TeamName);
         }
+
+
+        public void Dispose()
+        {
+            client.Delete<Team>(x => x.TeamName.Match(team1.TeamName));
+            client.Delete<Team>(x => x.TeamName.Match(team2.TeamName));
+        }
     }
 
-    public class Nested2
+    public class Nested2 : IDisposable
     {
         [Fact]
         public void FilterByMultipleValuesForAComplexObjectInAListUsingFilterDelegateBuilder()
@@ -183,9 +192,15 @@ namespace Nested2Find.Stories
         {
             result.Single().TeamName.Should().Be(team1.TeamName);
         }
+
+        public void Dispose()
+        {
+            client.Delete<Team>(x => x.TeamName.Match(team1.TeamName));
+            client.Delete<Team>(x => x.TeamName.Match(team2.TeamName));
+        }
     }
 
-    public class Nested3
+    public class Nested3 : IDisposable
     {
         [Fact]
         public void FilterByMultipleValuesForANestedListOfComplexObjectsUsingFilterDelegateBuilder()
@@ -288,6 +303,12 @@ namespace Nested2Find.Stories
         void ItShouldBeForTheFirstTeam()
         {
             result.Single().LeagueName.Should().Be(league1.LeagueName);
+        }
+
+        public void Dispose()
+        {
+            client.Delete<League>(x => x.LeagueName.Match(league1.LeagueName));
+            client.Delete<League>(x => x.LeagueName.Match(league1.LeagueName));
         }
     }
 

--- a/Nested2Find.Tests/packages.config
+++ b/Nested2Find.Tests/packages.config
@@ -2,7 +2,8 @@
 <packages>
   <package id="EPiServer.Find" version="8.10.0.1509" targetFramework="net45" />
   <package id="FluentAssertions" version="2.0.0.1" targetFramework="net40" requireReinstallation="True" />
-  <package id="Machine.Specifications" version="0.5.9" targetFramework="net40" />
+  <package id="Machine.Specifications" version="0.8.3" targetFramework="net45" />
+  <package id="Machine.Specifications.Should" version="0.7.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />
   <package id="StoryQ" version="2.0.5" targetFramework="net40" />
   <package id="xunit" version="1.9.1" targetFramework="net40" />

--- a/Nested2Find/NestedFilterExtensions.cs
+++ b/Nested2Find/NestedFilterExtensions.cs
@@ -64,6 +64,11 @@ namespace Nested2Find
                 {
                     PrependPathOnNestedFilters(path, obj);
                 }
+
+                if (obj is String && property.Name.Equals("Field")) // prepend path to field name properties
+                {
+                    property.SetValue(filterOrQuery, string.Format("{0}.{1}", path, obj));
+                }
             }
 
             return;
@@ -84,6 +89,7 @@ namespace Nested2Find
             }
             var parser = new FilterExpressionParser(search.Client.Conventions);
             var filter = parser.GetFilter(filterExpression);
+            PrependPathOnNestedFilters(path, filter);
             var nestedFilter = new NestedFilter(path, filter);
             return search.Filter(nestedFilter);
         }


### PR DESCRIPTION
Fix for an issue when a container object has a property with the same name as a nested objects. In that case search query with NestedFilter doesn't return any results if filtering was applied for the property.

The solution is to prepend all Field properties of child filters with path value (see [ElasticSearch doc](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-nested-filter.html))
